### PR TITLE
fix: properly pin Aragon client and add debug logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,8 +182,7 @@
             "pem-jwk": "^1.5.1",
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "tweetnacl": "^1.0.0"
           },
           "dependencies": {
             "multihashing-async": {
@@ -201,7 +200,7 @@
             },
             "webcrypto-shim": {
               "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-              "from": "github:dignifiedquire/webcrypto-shim#master"
+              "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
             }
           }
         },
@@ -284,8 +283,13 @@
                 "pem-jwk": "^1.5.1",
                 "protons": "^1.0.1",
                 "rsa-pem-to-jwk": "^1.1.3",
-                "tweetnacl": "^1.0.0",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+                "tweetnacl": "^1.0.0"
+              },
+              "dependencies": {
+                "webcrypto-shim": {
+                  "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+                  "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+                }
               }
             },
             "multiaddr": {
@@ -3203,8 +3207,17 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
         "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          }
+        }
       }
     },
     "ethereum-common": {
@@ -3221,14 +3234,6 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ethereum-provider/-/ethereum-provider-0.0.5.tgz",
       "integrity": "sha512-YPRq+JZxbg4DvS3cQGsM9rs3gZCeu2LPJUtDGnywoSKk+L9QPkcJhELggrOJ/ahmcc0sfRfvxXtxknFyivU1+Q=="
-    },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-      "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
-      }
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -5043,14 +5048,17 @@
         "pem-jwk": "^1.5.1",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "tweetnacl": "^1.0.0"
       },
       "dependencies": {
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -7708,7 +7716,6 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
           "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2-cookies": "^1.1.0",
@@ -7717,7 +7724,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
             }
           }
         },
@@ -7790,14 +7797,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "ultron": {
       "version": "1.1.1",
@@ -8254,7 +8253,6 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
@@ -8262,7 +8260,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-              "from": "git+https://github.com/debris/bignumber.js.git#master"
+              "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
             }
           }
         },
@@ -8298,8 +8296,19 @@
       "integrity": "sha512-wAnENuZx75T5ZSrT2De2LOaUuPf2yRjq1VfcbD7+Zd79F3DZZLBJcPyCNVQ1U0fAXt0wfgCKl7sVw5pffqR9Bw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.36"
+      },
+      "dependencies": {
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -8337,20 +8346,6 @@
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
-      }
-    },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
       }
     },
     "whatwg-fetch": {
@@ -8496,11 +8491,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/src/lib/aragon-core.js
+++ b/src/lib/aragon-core.js
@@ -14,8 +14,9 @@ async function getLatestFromRepo (repo) {
     { ensRegistryAddress, ipfs: { host: 'localhost', protocol: 'http', port: 5001 } }
   )
 
-  const { content } = await apm.getLatestVersion(repo)
-  return content.location
+  const repoDetails = await apm.getLatestVersion(repo)
+  console.log(`aragomPM latest content for ${repo}:`, repoDetails)
+  return repoDetails.content.location
 }
 
 module.exports = { getLatestFromRepo }

--- a/src/lib/ipfs-caching.js
+++ b/src/lib/ipfs-caching.js
@@ -1,4 +1,5 @@
 const url = require('url')
+const { promisify } = require('util')
 const { IpfsConnector } = require('@akashaproject/ipfs-connector')
 const { session } = require('electron')
 const storage = require('./storage')
@@ -6,18 +7,37 @@ const storage = require('./storage')
 // 7 days is the default expiration time if the pinned hash is not accessed
 const IPFS_EXPIRATION = 7
 
-const instance = IpfsConnector.getInstance()
+const ipfsInstance = IpfsConnector.getInstance()
+
+// Simple promisified cache for pinning operations
+let promisifiedIpfsPinAdd
+let promisifiedIpfsPinRm
+const ipfsPinAdd = (...args) => {
+  if (!promisifiedIpfsPinAdd) {
+    promisifiedIpfsPinAdd = promisify(ipfsInstance.api.ipfsApi.pin.add)
+  }
+  promisifiedIpfsPinAdd(...args)
+}
+const ipfsPinRm = (...args) => {
+  if (!promisifiedIpfsPinRm) {
+    promisifiedIpfsPinRm = promisify(ipfsInstance.api.ipfsApi.pin.add)
+  }
+  promisifiedIpfsPinRm(...args)
+}
 
 const ipfsFilter = {
   urls: ['https://localhost:8080/ipfs/*']
 }
 
-async function pinAragonCore (newHash) {
+async function pinAragonClient (newHash) {
   const storedHash = storage.get('aragon.aragonpm.eth')
   if (storedHash !== newHash) {
-    instance.api.apiClient.pin.add(newHash)
-    instance.api.apiClient.pin.rm(storedHash)
+    await ipfsPinAdd(newHash)
+    if (storedHash) {
+      await ipfsPinRm(storedHash)
+    }
     await storage.set('aragon.aragonpm.eth', { hash: newHash })
+    console.log('Pinned new client hash:', newHash)
   }
 }
 
@@ -33,11 +53,12 @@ async function purgeUnusedIpfsResources () {
     const data = await storage.get(key)
     if (data.expiration) {
       if (data.expiration < new Date().getTime()) {
-        instance.api.apiClient.pin.rm(hash)
+        await ipfsPinRm(hash)
         await storage.delete(hash)
       }
     }
   }
+  console.log('Purged old IPFS resources')
 }
 
 function pinIpfsResources () {
@@ -46,12 +67,13 @@ function pinIpfsResources () {
     if (path.startsWith('/ipfs/')) {
       const hash = path.split('/')[2]
       if (!storage.has(hash)) {
-        instance.api.apiClient.pin.add(hash)
+        ipfsPinAdd(hash)
       }
       updateExpiration(hash)
+      console.log('Pinned new IPFS resource:', hash)
     }
     cb({ cancel: false, requestHeaders: details.requestHeaders })
   })
-} 
+}
 
-module.exports = { pinAragonCore, pinIpfsResources, purgeUnusedIpfsResources }
+module.exports = { pinAragonClient, pinIpfsResources, purgeUnusedIpfsResources }


### PR DESCRIPTION
Promisifies the ipfs-http-client pinning API (which may have caused race conditions with loading off of it before), fixes how it's accessed (`apiClient` doesn't seem to be in the current version of ipfs-connector's API) and add some debug logging.