### PR TITLE
Add TouchBar support

### DIFF
--- a/src/injections/hook.js
+++ b/src/injections/hook.js
@@ -1,0 +1,46 @@
+const { ipcRenderer } = require('electron')
+
+// Handle navigation requests from the TouchBar to apps
+ipcRenderer.on('navigate-to-app', (_, app) => {
+  const clientHash = location.href.split('/')[4]
+  const dao = location.href.split('/')[6]
+  window.location.href = `http://localhost:8080/ipfs/${clientHash}/#/${dao}/${app}`
+})
+
+function hook () {
+  // Find React root
+  const root = document.getElementById('root')
+  const el = root.children[0]
+  const internalInstanceKey = Object.keys(el).find(
+    (key) => el.hasOwnProperty(key) && key.startsWith('__reactInternalInstance$')
+  )
+  
+  if (!internalInstanceKey) {
+    // Root not found
+  }
+  
+  const fiberNode = el[internalInstanceKey]
+  
+  if (!(fiberNode
+    && fiberNode.return
+    && fiberNode.return.stateNode
+    && fiberNode.return.stateNode._reactInternalFiber.return)) {
+    // Root not found
+  }
+  
+  // Try to determine props
+  const component = fiberNode.return.stateNode._reactInternalFiber.return
+  const props = component.memoizedProps
+  
+  // The wrapper is not available yet, so let's try again later
+  if (!props.wrapper) {
+    console.debug('Wrapper not available, waiting...')
+    setTimeout(hook, 500)
+  } else {
+    props.wrapper.apps.subscribe((apps) => {
+      ipcRenderer.send('apps', apps)
+    })
+  }
+}
+
+window.onload = hook

--- a/src/injections/hook.js
+++ b/src/injections/hook.js
@@ -32,6 +32,14 @@ function findReactProps (el) {
 }
 
 function hook () {
+  // We're probably still on the loading screen
+  const dao = location.href.split('/')[6]
+  if (!dao) {
+    console.debug('No DAO open...')
+    setTimeout(hook, 500)
+    return
+  }
+
   // Find React props for root component
   const props = findReactProps(
     document.getElementById('root').children[0]

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, shell } = require('electron')
 const windowStateKeeper = require('electron-window-state')
 const { IpfsConnector } = require('@akashaproject/ipfs-connector')
 const path = require('path')
+const hookTouchBar = require('./touchbar')
 
 const { getLatestFromRepo } = require('./lib/aragon-core')
 const {
@@ -45,8 +46,9 @@ function createWindow () {
     backgroundColor: '#f7fbfd',
     icon: path.join(__dirname, 'app/assets/icon.png'),
     webPreferences: {
-      nodeIntegration: false
-    }
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'injections', 'hook.js')
+    },
   })
 
   mainWindow.setMenu(null)
@@ -56,15 +58,16 @@ function createWindow () {
   mainWindow.loadURL(`file://${path.join(__dirname, '../assets/loading.html')}`)
 
   start(mainWindow)
+  hookTouchBar(mainWindow)
 
   setTimeout(() => mainWindow.webContents.openDevTools({mode: 'detach'}), 1000)
 
   // Sniff new windows from anchors and open in external browsers instead
-  mainWindow.webContents.on('new-window', function(event, url){
-    event.preventDefault();
+  mainWindow.webContents.on('new-window', function(event, url) {
+    event.preventDefault()
     console.log(`Opening ${url} in an external browser`)
     shell.openExternal(url)
-  });
+  })
 
   // Sniff navigation requests
   const navigationRegex = /https?:\/\/(rinkeby|mainnet).aragon.org\/?/

--- a/src/touchbar.js
+++ b/src/touchbar.js
@@ -1,0 +1,37 @@
+const {
+  TouchBar,
+  ipcMain
+} = require('electron')
+const {
+  TouchBarLabel,
+  TouchBarButton
+} = TouchBar
+
+function createTouchBar (win, apps) {
+  if (!apps.length) {
+    return new TouchBar([
+      new TouchBarLabel({ label: 'Loading apps...' })
+    ])
+  }
+
+  const buttons = apps.filter(
+    (app) => app.start_url
+  ).map(
+    (app) => new TouchBarButton({
+      label: app.name,
+      click: () => win.webContents.send('navigate-to-app', app.proxyAddress)
+    })
+  )
+  
+  return new TouchBar(
+    buttons
+  )
+}
+
+module.exports = function hookTouchBar (win) {
+  ipcMain.on('apps', (_, apps) => {
+    win.setTouchBar(
+      createTouchBar(win, apps)
+    )
+  })    
+}


### PR DESCRIPTION
This is a lil ugly hack to add TouchBar support.

It reaches in to React internals to pull a reference to the aragonAPI wrapper instance and then it listens for the apps and sends this over to the main process using IPC.

The hook also listens for messages from the main process over IPC in order to handle navigation requests from the TouchBar.

The TouchBar displays the installed apps in the organisation, and when you click on them, you navigate to that app.

Some possible improvements:

- Showing a popover of your favorite DAOs for the current network to allow easy switching between DAOs
- A button for notifications
- If Aragon ever gets per-app shortcuts then a list of these could be shown depending on the open app

**Demo**

![screen recording 2019-01-28 at 14 17 53](https://user-images.githubusercontent.com/8862627/51838875-deba3800-2307-11e9-8ac9-3b87ddaa4829.gif)