### PR TITLE
Only show devtools during development

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,9 @@ function createWindow () {
 
   start(mainWindow)
 
-  setTimeout(() => mainWindow.webContents.openDevTools({mode: 'detach'}), 1000)
+  if (process.env.NODE_ENV === 'development') {
+    setTimeout(() => mainWindow.webContents.openDevTools({mode: 'detach'}), 1000)
+  }
 
   // Sniff new windows from anchors and open in external browsers instead
   mainWindow.webContents.on('new-window', function(event, url){


### PR DESCRIPTION
Running with devtools: `NODE_ENV=development npm start`
Running without devtools: `npm start`