### PR TITLE
Add links to build artifacts in GitHub build status

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,16 +4,36 @@ set -e
 # Build for Mac & Linux
 npm run dist -- -ml
 
-# Upload artifacts
+# Helpers
 transfer() {
-    curl --progress-bar --upload-file "$1" https://transfer.sh/$(basename $1) | tee /dev/null;
+    curl --progress-bar --upload-file "$1" "https://transfer.sh/$(basename $1)" | tee /dev/null;
 }
 
+function status() {
+	platform=$1
+	artifact_url=$2
+	endpoint=https://api.github.com/repos/aragon/aragon-desktop/statuses/$TRAVIS_COMMIT
+
+	echo "{
+		\"state\": \"success\",
+		\"target_url\": \"$artifact_url\",
+		\"description\": \"Build artifact ($platform)\",
+		\"context\": \"build-artifact/$platform\"
+	}" | curl --data @- \
+		-H "Content-Type: application/json" \
+		-H "authToken: $GH_TOKEN" \
+		$endpoint
+}
+
+# Upload artifacts
 echo "Uploading Mac artifact..."
-transfer "./dist/Aragon Desktop.dmg"
+artifact=$(transfer "./dist/Aragon Desktop.dmg")
+status macos $artifact
 
 echo "Uploading Linux (snap) artifact..."
-transfer "./dist/Aragon Desktop.snap"
+artifact=$(transfer "./dist/Aragon Desktop.snap")
+status snap $artifact
 
 echo "Uploading Linux (AppImage) artifact..."
-transfer "./dist/Aragon Desktop.AppImage"
+artifact=$(transfer "./dist/Aragon Desktop.AppImage")
+status appimage $artifact


### PR DESCRIPTION
This PR adds links to build artifacts on GitHub so you don't need to open up Travis to get the URLs using the [GitHub Status API](https://developer.github.com/v3/repos/statuses/).

For this to work, the `GH_TOKEN` environment variable needs to be set to an access token with the `repo:status` OAuth scope.

This change also includes a small fix for the uploading of artifacts - now the resulting artifact URL includes the file type so you don't have to guess.