### PR TITLE
chore: only run travis once with all env vars enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ osx_image: xcode9.4
 language: node_js
 node_js: "10"
 env:
-  - ELECTRON_CACHE=$HOME/.cache/electron
-  - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+  global:
+    - ELECTRON_CACHE=$HOME/.cache/electron
+    - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 
 cache:
   directories:


### PR DESCRIPTION
Doesn't seem like we're meant to run two builds for these env vars, but rather one with both.

cc @onbjerg 