### PR TITLE
chore: only run build and transfer in CI if on PR branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - $HOME/.cache/electron
     - $HOME/.cache/electron-builder
 
-script:
+after_success:
   - ./bin/build
 
 branches:

--- a/bin/build
+++ b/bin/build
@@ -1,28 +1,33 @@
 #!/bin/bash
 set -e
 
+if [ -z "$TRAVIS_PULL_REQUEST_SHA"]; then
+  echo "Skipping build on non-PR push"
+  exit 0
+fi
+
 # Build for Mac & Linux
 npm run dist -- -ml
 
 # Helpers
 transfer() {
-    curl --progress-bar --upload-file "$1" "https://transfer.sh/$(basename $1)" | tee /dev/null;
+  curl --progress-bar --upload-file "$1" "https://transfer.sh/$(basename $1)" | tee /dev/null;
 }
 
 function status() {
-	platform=$1
-	artifact_url=$2
-	endpoint=https://api.github.com/repos/aragon/aragon-desktop/statuses/$TRAVIS_COMMIT
+  platform=$1
+  artifact_url=$2
+  endpoint=https://api.github.com/repos/aragon/aragon-desktop/statuses/$TRAVIS_PULL_REQUEST_SHA
 
-	echo "{
-		\"state\": \"success\",
-		\"target_url\": \"$artifact_url\",
-		\"description\": \"Build artifact ($platform)\",
-		\"context\": \"build-artifact/$platform\"
-	}" | curl --data @- \
-		-H "Content-Type: application/json" \
-		-H "Authorization: token $GH_TOKEN" \
-		$endpoint
+  echo "{
+    \"state\": \"success\",
+    \"target_url\": \"$artifact_url\",
+    \"description\": \"Build artifact ($platform)\",
+    \"context\": \"build-artifact/$platform\"
+  }" | curl --data @- \
+    -H "Content-Type: application/json" \
+    -H "Authorization: token $GH_TOKEN" \
+    $endpoint
 }
 
 # Upload artifacts


### PR DESCRIPTION
Turns out `TRAVIS_COMMIT` is the merge commit, so it doesn't actually leave a status on the PR itself.

This switches the build script to only be run on PRs and leaves the default test hook for all branches (should at least lint :D).

cc @onbjerg 