### PR TITLE
fix: detect already running instance of IPFS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@ async function loadAragonClient (network = 'main') {
 async function start (mainWindow) {
   try {
     const version = await ipfsInstance.api.ipfsApi.version()
-    console.log('Detected running instance of IPFS, no need to start our own')
+    console.log(`Detected running instance of IPFS ${version ? `(version: ${version.version})` : ''}, no need to start our own`)
   } catch (e) {
     console.log('Could not detect running instance of IPFS, starting it ourselves...')
     await ipfsInstance.start()


### PR DESCRIPTION
Fixes #28 

A bit hacky, but seems to work ok 👌. Accessing the IPFS api (e.g. pinning) seems to work with a pre-existing daemon as long as the daemon's running on the default port.

cc @onbjerg 